### PR TITLE
feat: proper asyncio support, horde context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 out.json
 .vscode/launch.json
 .vscode/settings.json
+
+examples/requested_images/*.*

--- a/examples/ai_horde_api_client.example.py
+++ b/examples/ai_horde_api_client.example.py
@@ -1,16 +1,16 @@
-from horde_sdk.ai_horde_api import AIHordeAPIClient
+from horde_sdk.ai_horde_api import AIHordeAPISimpleClient
 from horde_sdk.ai_horde_api.apimodels import ImageGenerateAsyncRequest
 from horde_sdk.generic_api.apimodels import RequestErrorResponse
 
 
-def do_generate_check(ai_horde_api_client: AIHordeAPIClient) -> None:
+def do_generate_check(ai_horde_api_client: AIHordeAPISimpleClient) -> None:
     pass
 
 
 def main() -> None:
     """Just a proof of concept - but several other pieces of functionality exist."""
 
-    ai_horde_api_client = AIHordeAPIClient()
+    ai_horde_api_client = AIHordeAPISimpleClient()
 
     image_generate_async_request = ImageGenerateAsyncRequest(
         apikey="0000000000",

--- a/examples/async_ai_horde_api_client_example.py
+++ b/examples/async_ai_horde_api_client_example.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from pathlib import Path
 
-from horde_sdk.ai_horde_api import AIHordeAPIClient
-from horde_sdk.ai_horde_api.apimodels import ImageGenerateAsyncRequest
+import aiohttp
+
+from horde_sdk.ai_horde_api import AIHordeAPISimpleClient
+from horde_sdk.ai_horde_api.apimodels import ImageGenerateAsyncRequest, ImageGenerateStatusRequest
 from horde_sdk.generic_api.apimodels import RequestErrorResponse
 
 
 async def main() -> None:
     print("Starting...")
-    ai_horde_api_client = AIHordeAPIClient()
+    ai_horde_api_client = AIHordeAPISimpleClient()
 
     image_generate_async_request = ImageGenerateAsyncRequest(
         apikey="0000000000",
         prompt="A cat in a hat",
         models=["Deliberate"],
     )
-
+    print("Submitting image generation request...")
     response = await ai_horde_api_client.async_submit_request(
         image_generate_async_request,
         image_generate_async_request.get_success_response_type(),
@@ -26,8 +30,17 @@ async def main() -> None:
         print(f"Error: {response.message}")
         return
 
+    print("Image generation request submitted!")
+    image_done = False
+    start_time = time.time()
+    check_counter = 0
     # Keep making ImageGenerateCheckRequests until the job is done.
-    while True:
+    while not image_done:
+        if time.time() - start_time > 20 or check_counter == 0:
+            print(f"{time.time() - start_time} seconds elapsed ({check_counter} checks made)...")
+            start_time = time.time()
+
+        check_counter += 1
         check_response = await ai_horde_api_client.async_get_generate_check(
             apikey="0000000000",
             generation_id=response.id_,
@@ -38,9 +51,50 @@ async def main() -> None:
             return
 
         if check_response.done:
+            print("Image is done!")
+            image_done = True
             break
 
         await asyncio.sleep(5)
+
+    # Get the image with a ImageGenerateStatusRequest.
+    image_generate_status_request = ImageGenerateStatusRequest(
+        id=response.id_,
+    )
+
+    status_response = await ai_horde_api_client.async_submit_request(
+        image_generate_status_request,
+        image_generate_status_request.get_success_response_type(),
+    )
+
+    if isinstance(status_response, RequestErrorResponse):
+        print(f"Error: {status_response.message}")
+        return
+
+    for image_gen in status_response.generations:
+        print("Image generation:")
+        print(f"ID: {image_gen.id}")
+        print(f"URL: {image_gen.img}")
+        #  debug(image_gen)
+        print("Downloading image...")
+
+        image_bytes = None
+        # image_gen.img is a url, download it using aiohttp.
+        async with aiohttp.ClientSession() as session, session.get(image_gen.img) as resp:
+            image_bytes = await resp.read()
+
+        if image_bytes is None:
+            print("Error: Could not download image.")
+            return
+
+        # Open a file in write mode and write the image bytes to it.
+        dir_to_write_to = Path("examples/requested_images/")
+        dir_to_write_to.mkdir(parents=True, exist_ok=True)
+        filepath_to_write_to = dir_to_write_to / f"{image_gen.id}.webp"
+        with open(filepath_to_write_to, "wb") as image_file:
+            image_file.write(image_bytes)
+
+        print(f"Image downloaded to {filepath_to_write_to}!")
 
 
 if __name__ == "__main__":

--- a/horde_sdk/ai_horde_api/__init__.py
+++ b/horde_sdk/ai_horde_api/__init__.py
@@ -1,5 +1,5 @@
 from horde_sdk.ai_horde_api.ai_horde_client import (
-    AIHordeAPIClient,
+    AIHordeAPISimpleClient,
 )
 from horde_sdk.ai_horde_api.consts import (
     ALCHEMY_FORMS,
@@ -14,7 +14,7 @@ from horde_sdk.ai_horde_api.endpoints import (
 )
 
 __all__ = [
-    "AIHordeAPIClient",
+    "AIHordeAPISimpleClient",
     "AI_HORDE_BASE_URL",
     "AI_HORDE_API_URL_Literals",
     "ALCHEMY_FORMS",

--- a/horde_sdk/ai_horde_api/apimodels/generate/_async.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_async.py
@@ -5,12 +5,17 @@ from horde_sdk.ai_horde_api.apimodels.base import (
     BaseAIHordeRequest,
     BaseImageGenerateParam,
 )
-from horde_sdk.ai_horde_api.apimodels.generate._status import DeleteImageGenerateRequest
+from horde_sdk.ai_horde_api.apimodels.generate._check import ImageGenerateCheckRequest
+from horde_sdk.ai_horde_api.apimodels.generate._status import DeleteImageGenerateRequest, ImageGenerateStatusRequest
 from horde_sdk.ai_horde_api.consts import KNOWN_SOURCE_PROCESSING
 from horde_sdk.ai_horde_api.endpoints import AI_HORDE_API_URL_Literals
 from horde_sdk.ai_horde_api.fields import GenerationID
 from horde_sdk.consts import HTTPMethod, HTTPStatusCode
-from horde_sdk.generic_api.apimodels import BaseRequestAuthenticated, BaseRequestWorkerDriven, BaseResponse
+from horde_sdk.generic_api.apimodels import (
+    BaseRequestAuthenticated,
+    BaseRequestWorkerDriven,
+    BaseResponse,
+)
 
 
 class ImageGenerateAsyncResponse(BaseResponse):
@@ -19,10 +24,30 @@ class ImageGenerateAsyncResponse(BaseResponse):
     v2 API Model: `RequestAsync`
     """
 
-    id_: str | GenerationID = Field(alias="id")
+    id_: str | GenerationID = Field(alias="id")  # TODO: Remove `str`?
     """The UUID for this image generation."""
     kudos: float
     message: str | None = None
+
+    @override
+    @classmethod
+    def is_requiring_follow_up(cls) -> bool:
+        return True
+
+    @override
+    def get_follow_up_data(self) -> dict[str, object]:
+        return {"id": self.id_}
+
+    @classmethod
+    def get_follow_up_default_request(cls) -> type[ImageGenerateCheckRequest]:
+        return ImageGenerateCheckRequest
+
+    @override
+    @classmethod
+    def get_follow_up_request_types(
+        cls,
+    ) -> list[type[ImageGenerateCheckRequest | ImageGenerateStatusRequest]]:
+        return [ImageGenerateCheckRequest, ImageGenerateStatusRequest]
 
     @override
     @classmethod

--- a/horde_sdk/ai_horde_api/apimodels/generate/_status.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_status.py
@@ -7,7 +7,6 @@ from horde_sdk.ai_horde_api.consts import GENERATION_STATE
 from horde_sdk.ai_horde_api.endpoints import AI_HORDE_API_URL_Literals
 from horde_sdk.ai_horde_api.fields import ImageID, WorkerID
 from horde_sdk.consts import HTTPMethod
-from horde_sdk.generic_api.apimodels import BaseRequestAuthenticated
 
 
 class ImageGeneration(BaseModel):
@@ -53,7 +52,6 @@ class ImageGenerateStatusResponse(ImageGenerateCheckResponse):
 
 class DeleteImageGenerateRequest(
     BaseAIHordeRequest,
-    BaseRequestAuthenticated,
     BaseImageJobRequest,
 ):
     """Represents a DELETE request to the `/v2/generate/status/{id}` endpoint."""

--- a/horde_sdk/generic_api/metadata.py
+++ b/horde_sdk/generic_api/metadata.py
@@ -11,6 +11,7 @@ class GenericHeaderFields(StrEnum):
     apikey = auto()
     accept = auto()
     # X_Fields = "X-Fields" # TODO?
+    client_agent = auto()
 
 
 class GenericAcceptTypes(StrEnum):

--- a/horde_sdk/ratings_api/apimodels.py
+++ b/horde_sdk/ratings_api/apimodels.py
@@ -270,7 +270,6 @@ class UserRatingsRequest(
     limit: int
     offset: int = 0
     diverge: int | None
-    client_agent: str | None
 
     @override
     @classmethod

--- a/horde_sdk/ratings_api/ratings_client.py
+++ b/horde_sdk/ratings_api/ratings_client.py
@@ -1,9 +1,9 @@
 """Definitions to help interact with the Ratings API."""
-from horde_sdk.generic_api.generic_client import GenericHordeAPIClient
+from horde_sdk.generic_api.generic_client import GenericHordeAPISimpleClient
 from horde_sdk.ratings_api.metadata import RatingsAPIPathFields, RatingsAPIQueryFields
 
 
-class RatingsAPIClient(GenericHordeAPIClient):
+class RatingsAPIClient(GenericHordeAPISimpleClient):
     """Represent a client specifically configured for the Ratings APi."""
 
     def __init__(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "babel",
     "aiohttp",
     "aiodns",
+    "pillow",
 ]
 license = {file = "LICENSE"}
 classifiers = [

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,10 @@
 pytest==7.4.0
+pytest-asyncio
 mypy==1.4.1
 black==23.3.0
 ruff==0.0.275
 types-requests==2.31.0.1
+types-Pillow
 types-pytz
 types-setuptools
 types-urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ StrEnum
 loguru
 aiohttp
 aiodns
+pillow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,19 @@
+import pytest
+
+from horde_sdk.ai_horde_api.apimodels import (
+    ImageGenerateAsyncRequest,
+)
+
+
+@pytest.fixture(scope="function")
+def simple_image_gen_request() -> ImageGenerateAsyncRequest:
+    return ImageGenerateAsyncRequest(
+        apikey="0000000000",
+        prompt="a cat in a hat",
+        models=["Deliberate"],
+    )
+
+
 def pytest_collection_modifyitems(items: list) -> None:
     """Modifies test items in place to ensure test modules run in a given order."""
     MODULE_ORDER = ["tests_generic", "test_utils", "test_dynamically_check_apimodels"]


### PR DESCRIPTION
- e.g. `AIHordeAPISimpleClient`, `AIHordeAPISession`, and `AIHordeAPIClient` all support `async`/`await` operations.
- Requests which require some sort of follow up, such as image generation requests, now can have the appropriate cancel request sent automatically with
- See `AIHordeAPISession` (new context handler) or its usage in `test_ai_horde_api_calls.py` for an idea of what was accomplished.