### PR TITLE
fix: use API visible field name for steps/n_iter

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/generate/_async.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_async.py
@@ -1,4 +1,4 @@
-from pydantic import model_validator
+from pydantic import AliasChoices, Field, model_validator
 from typing_extensions import override
 
 from horde_sdk.ai_horde_api.apimodels.base import (
@@ -76,6 +76,12 @@ class ImageGenerationInputPayload(HordeAPIObject, ImageGenerateParamMixin):
 
     v2 API Model: `ModelGenerationInputStable`
     """
+
+    steps: int = Field(default=25, ge=1, validation_alias=AliasChoices("steps", "ddim_steps"))
+    """The number of image generation steps to perform."""
+
+    n: int = Field(default=1, ge=1, le=20, validation_alias=AliasChoices("n", "n_iter"))
+    """The number of images to generate. Defaults to 1, maximum is 20."""
 
     @override
     @classmethod

--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -1,5 +1,5 @@
 import pydantic
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from typing_extensions import override
 
 from horde_sdk.ai_horde_api.apimodels.base import (
@@ -63,6 +63,11 @@ class ImageGenerateJobPopSkippedStatus(pydantic.BaseModel):
 
 class ImageGenerateJobPopPayload(ImageGenerateParamMixin):
     prompt: str
+    ddim_steps: int = Field(default=25, ge=1, validation_alias=AliasChoices("steps", "ddim_steps"))
+    """The number of image generation steps to perform."""
+
+    n_iter: int = Field(default=1, ge=1, le=20, validation_alias=AliasChoices("n", "n_iter"))
+    """The number of images to generate. Defaults to 1, maximum is 20."""
 
 
 class ImageGenerateJobResponse(HordeResponseBaseModel, JobResponseMixin, ResponseRequiringFollowUpMixin):

--- a/horde_sdk/ai_horde_worker/model_meta.py
+++ b/horde_sdk/ai_horde_worker/model_meta.py
@@ -14,7 +14,7 @@ class ImageModelLoadResolver:
     """Resolve meta instructions for loading models."""
 
     # set a default timeframe for model stats
-    default_timeframe = StatsModelsTimeframe.day
+    default_timeframe = StatsModelsTimeframe.month
 
     _model_reference_manager: ModelReferenceManager
 

--- a/horde_sdk/ai_horde_worker/model_meta.py
+++ b/horde_sdk/ai_horde_worker/model_meta.py
@@ -130,8 +130,8 @@ class ImageModelLoadResolver:
         """
         models_in_timeframe = response.get_timeframe(timeframe)
 
-        # Remove the `None` values from the dict
-        models_in_timeframe = {k: v for k, v in models_in_timeframe.items() if v is not None}
+        # Remove the blank or null values from the dict
+        models_in_timeframe = {k: v for k, v in models_in_timeframe.items() if k and v is not None}
 
         # Sort by value (number of uses) ascending (highest first)
         sorted_models = sorted(models_in_timeframe.items(), key=lambda x: x[1], reverse=True)
@@ -140,7 +140,7 @@ class ImageModelLoadResolver:
         top_n_models = sorted_models[:number_of_top_models]
 
         # Get just the model names as a list
-        return [model[0] for model in top_n_models if model]
+        return [model[0] for model in top_n_models]
 
     @staticmethod
     def resolve_bottom_n_model_names(
@@ -160,6 +160,9 @@ class ImageModelLoadResolver:
         """
         models_in_timeframe = response.get_timeframe(timeframe)
 
+        # Remove the blank or null values from the dict
+        models_in_timeframe = {k: v for k, v in models_in_timeframe.items() if k and v is not None}
+
         # Sort by value (number of uses) ascending (lowest first)
         sorted_models = sorted(models_in_timeframe.items(), key=lambda x: x[1])
 
@@ -167,4 +170,4 @@ class ImageModelLoadResolver:
         bottom_n_models = sorted_models[:number_of_bottom_models]
 
         # Get just the model names as a list
-        return [model[0] for model in bottom_n_models if model]
+        return [model[0] for model in bottom_n_models]

--- a/horde_sdk/ai_horde_worker/model_meta.py
+++ b/horde_sdk/ai_horde_worker/model_meta.py
@@ -140,7 +140,7 @@ class ImageModelLoadResolver:
         top_n_models = sorted_models[:number_of_top_models]
 
         # Get just the model names as a list
-        return [model[0] for model in top_n_models]
+        return [model[0] for model in top_n_models if model]
 
     @staticmethod
     def resolve_bottom_n_model_names(
@@ -167,4 +167,4 @@ class ImageModelLoadResolver:
         bottom_n_models = sorted_models[:number_of_bottom_models]
 
         # Get just the model names as a list
-        return [model[0] for model in bottom_n_models]
+        return [model[0] for model in bottom_n_models if model]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_sdk"
-version = "0.7.3"
+version = "0.7.4"
 description = "A python toolkit for interacting with the horde APIs, services, and ecosystem."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: GNU Affero General Public License v3",
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
 ]
 
 [tool.setuptools.package-dir]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_sdk"
-version = "0.7.4"
+version = "0.7.5"
 description = "A python toolkit for interacting with the horde APIs, services, and ecosystem."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},


### PR DESCRIPTION
- `GenerationInputStable` (`/v2/generate/async/`) on the API uses `n` and `steps`
- `GenerationPayloadStable`, which contains `ModelPayloadStable` (`/v2/generate/pop`) uses `n_iter` and `ddim_steps`

At some point along the way, I lost grasp of this, and 'fixed' it so they were consistent in the SDK. This changes things so the field name in the SDK matches the API definition, but it also accepts the corresponding name as a validation alias.


