### PR TITLE
feat: allow flexible `AIHordeAPIAsyncClientSession` context

### DIFF
--- a/horde_sdk/ai_horde_api/fields.py
+++ b/horde_sdk/ai_horde_api/fields.py
@@ -41,11 +41,14 @@ class UUID_Identifier(RootModel[uuid.UUID]):
 
     @override
     def __eq__(self, other: Any) -> bool:
+        if isinstance(other, UUID_Identifier):
+            return self.root == other.root
+
         if isinstance(other, str):
             return self.root.__str__() == other
 
         if isinstance(other, uuid.UUID):
-            return str(self.root) == str(other)
+            return self.root == other
 
         return False
 

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -639,7 +639,8 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
     ) -> HordeResponseTypeVar | RequestErrorResponse:
         # Add the request to the list of awaiting requests.
 
-        self._awaiting_requests.append(api_request)
+        async with self._awaiting_requests_lock:
+            self._awaiting_requests.append(api_request)
 
         # Submit the request to the API and get the response.
         response = await super().submit_request(api_request, expected_response_type)
@@ -783,6 +784,7 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
             # Log the results of each cleanup request.
             for i, cleanup_response in enumerate(cleanup_responses):
                 logger.info(f"Recovery request {i+1} submitted!")
+                logger.debug(f"Recovery request {i+1}: {cleanup_requests[i].log_safe_model_dump()}")
                 logger.debug(f"Recovery response {i+1}: {cleanup_response}")
 
             # Return True to indicate that all requests were handled successfully.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_sdk"
-version = "0.7.7"
+version = "0.7.9"
 description = "A python toolkit for interacting with the horde APIs, services, and ecosystem."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},

--- a/tests/ai_horde_api/test_dynamically_validate_against_swagger.py
+++ b/tests/ai_horde_api/test_dynamically_validate_against_swagger.py
@@ -109,9 +109,11 @@ def all_ai_horde_model_defs_in_swagger(swagger_doc: SwaggerDoc) -> None:
 
     with open("docs/api_to_sdk_payload_map.json", "w") as f:
         f.write(json.dumps(api_to_sdk_payload_model_map, indent=4, default=json_serializer))
+        f.write("\n")
 
     with open("docs/api_to_sdk_response_map.json", "w") as f:
         f.write(json.dumps(api_to_sdk_response_model_map, indent=4, default=json_serializer))
+        f.write("\n")
 
 
 def test_all_ai_horde_model_defs_in_swagger_from_prod_swagger() -> None:


### PR DESCRIPTION
On instantiating a `AIHordeAPIAsyncSimpleClient`, you now have the option of passing a `AIHordeAPIAsyncClientSession`. It is the responsibility of the caller to have used it with a `with` statement to still enable the automatically request cleanup on an exception.

This allows more flexibility in the design of loops which make these sort of calls, such as for the worker, while still having the benefits of it's context management.