### PR TITLE
ci: feat: support publish to pypi on push to `releases` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: horde_sdk build and publish
+
+on:
+  push:
+    branches:
+      - releases
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  build-n-publish:
+    name: horde_sdk build and publish
+    runs-on: ubuntu-latest
+
+    environment: # see https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/
+      name: pypi
+      url: https://pypi.org/p/horde-sdk/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+
+    - name: "📣 Release on push"
+      id: release
+      uses: rymndhng/release-on-push-action@v0.28.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        bump_version_scheme: patch
+        use_github_release_notes: true
+
+    - name: "✔️ Checkout"
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    # Pass the version number in an env var to the below steps
+    - name: Set build version env var
+      run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.release.outputs.version }}" >> $GITHUB_ENV
+
+    # We need python...
+    - name: "🐍 Set up Python 3.10"
+      if: ${{ steps.release.outputs.version != '' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    # Install build deps
+    - name: "🛠 Install pypa/build"
+      if: ${{ steps.release.outputs.version != '' }}
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+
+    - name: "✏️ Install changelog dependencies"
+      if: ${{ steps.release.outputs.version != '' }}
+      uses: actions/setup-node@v3
+
+    - name: "✏️ Generate release changelog"
+      if: ${{ steps.release.outputs.version != '' }}
+      run: |
+        npm -g install auto-changelog
+        auto-changelog --template=.changelog --ignore-commit-pattern="update changelog|version bump|Merge pull"
+
+    # Try to add the changelog back to the releases branch
+    - uses: EndBug/add-and-commit@v9
+      with:
+        add: 'CHANGELOG.md'
+        message: 'ci: update changelog'
+        committer_name: GitHub Actions
+        committer_email: actions@github.com
+
+    # Build a pypi distribution using the env var version number
+    - name: "🔧 Build a binary wheel and a source tarball"
+      if: ${{ steps.release.outputs.version != '' }}
+      run: >-
+        python -m build --sdist --wheel --outdir dist/ .
+
+    # Publish the package
+    - name: "📦 Publish distribution to PyPI"
+      if: ${{ steps.release.outputs.version != '' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    # # Update the badges (maybe, if we're lucky)
+    # - name: "📦 Refresh pypi badge cache"
+    #   run: >-
+    #     curl -X PURGE
+    #     url_here
+
+    # - name: "📦 Refresh downloads badge cache"
+    #   run: >-
+    #     curl -X PURGE
+    #     url_here
+
+    # - name: "Inform with Discord Webhook"
+    #   if: ${{ steps.release.outputs.version != '' }}
+    #   uses: tsickert/discord-webhook@v5.3.0
+    #   with:
+    #     webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+    #     content: "New version of hordelib has been published to pypi: ${{ steps.release.outputs.version }}. You can update your worker by running `./update-runtime.sh --hordelib` (Linux) or `update-runtime.cmd --hordelib` (Windows). Changelog: https://t.ly/z2vQ"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "horde_sdk"
-version = "0.7.15"
 description = "A python toolkit for interacting with the horde APIs, services, and ecosystem."
 authors = [
     {name = "tazlin", email = "tazlin.on.github@gmail.com"},
@@ -12,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-dynamic=["dependencies"]
+dynamic=["version", "dependencies"]
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -20,6 +19,9 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Development Status :: 4 - Beta",
 ]
+
+[tool.setuptools_scm]
+write_to = "horde_sdk/_version.py"
 
 [tool.setuptools.package-dir]
 horde_sdk = "horde_sdk"


### PR DESCRIPTION
Attempt number 1 to get pypi publishing handled by a github action as inspired by jug's take on it [in hordelib](https://github.com/Haidra-Org/hordelib/blob/main/.github/workflows/release.yml).

A notable difference is I am attempting to use [trusted publishing](https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/#trusted-publishing) instead of issuing a pypi auth token.