### PR TITLE
fix: don't crash when extra/new fields are returned due to api changes

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -110,7 +110,7 @@ class ImageGenerateParamMixin(BaseModel):
     v2 API Model: `ModelPayloadStable`
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True)  # , extra="forbid")
 
     sampler_name: KNOWN_SAMPLERS = KNOWN_SAMPLERS.k_lms
     """The sampler to use for this generation. Defaults to `KNOWN_SAMPLERS.k_lms`."""

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -46,7 +46,7 @@ class HordeResponse(HordeAPIMessage):
 
 
 class HordeResponseBaseModel(HordeResponse, BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True)  # , extra="forbid")
 
 
 class ResponseRequiringFollowUpMixin(abc.ABC):


### PR DESCRIPTION
Fixes the SDK crashing when certain API changes occur.

`extra="forbid"` wasn't really intended to be part of the production release. I will look at reworking it back into the testing somehow, as its more of sanity check for internal consistency rather than a useful feature to have.