### PR TITLE
fix: don't fail on seed 0 during job submit

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/generate/_submit.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_submit.py
@@ -37,11 +37,11 @@ class ImageGenerationJobSubmitRequest(BaseAIHordeRequest, JobRequestMixin, APIKe
     def validate_generation(self) -> ImageGenerationJobSubmitRequest:
         if self.generation == "":
             logger.error("Generation cannot be an empty string.")
-            logger.error(self)
+            logger.error(self.log_safe_model_dump())
 
         if self.seed == 0:
-            logger.error("Seed cannot be 0.")
-            logger.error(self)
+            logger.debug(f"Seed is 0 for {self.id_}. That might not be intended.")
+            logger.debug(self.log_safe_model_dump())
 
         return self
 


### PR DESCRIPTION
- This change changes the log message for when 0 is set as the seed in a submit payload to a `DEBUG` level message.
- As [seen in comfyui](https://github.com/comfyanonymous/ComfyUI/blob/e1345473413cafdd91e7af702b8950ed54d0556d/nodes.py#L1281), 0 is a valid value, and assuming the end user actually specified it, the SDK shouldn't be logging an error in this situation, but of the 2^64 allowed values, 0 is awfully specific, so I will continue logging a debug level message to track potential problems (such as default ints (0) being used).
