### PR TITLE
ci: fix: use forbid fields during ci

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache
       HORDE_MODEL_REFERENCE_MAKE_FOLDERS: 1
+      TESTS_ONGOING: 1
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache
+      TESTS_ONGOING: 1
       HORDE_MODEL_REFERENCE_MAKE_FOLDERS: 1
     runs-on: ubuntu-latest
     strategy:

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -109,7 +109,7 @@ def api_to_sdk_map_create_markdown() -> None:
             for http_status_code, _sdk_response_type in http_status_code_map.items():
                 f.write(
                     f"| {api_endpoint} | {http_status_code} | "
-                    "[{sdk_response_type.split('.')[-1]}][{sdk_response_type}] |\n",
+                    f"[{_sdk_response_type.split('.')[-1]}][{_sdk_response_type}] |\n",
                 )
 
 

--- a/docs/response_field_names_and_descriptions.json
+++ b/docs/response_field_names_and_descriptions.json
@@ -143,6 +143,10 @@
     ],
     "FindUserResponse": [
         [
+            "admin_comment",
+            "(Privileged) Comments from the horde admins about this user."
+        ],
+        [
             "account_age",
             "How many seconds since this account was created."
         ],
@@ -197,6 +201,10 @@
         [
             "sharedkey_ids",
             null
+        ],
+        [
+            "service",
+            "This user is a Horde service account and can provide the `proxied_user` field."
         ],
         [
             "special",

--- a/horde_sdk/ai_horde_api/apimodels/_find_user.py
+++ b/horde_sdk/ai_horde_api/apimodels/_find_user.py
@@ -66,6 +66,10 @@ class FindUserResponse(HordeResponseBaseModel):
     def get_api_model_name(cls) -> str | None:
         return "UserDetails"
 
+    admin_comment: str | None = Field(
+        default=None,
+        description="(Privileged) Comments from the horde admins about this user.",
+    )
     account_age: int | None = Field(
         default=None,
         description="How many seconds since this account was created.",
@@ -126,6 +130,11 @@ class FindUserResponse(HordeResponseBaseModel):
     """How many images, texts, megapixelsteps and tokens this user has generated or requested."""
     sharedkey_ids: list[str] | None = None
     """The IDs of the shared keys this user has access to."""
+    service: bool | None = Field(
+        default=None,
+        description="This user is a Horde service account and can provide the `proxied_user` field.",
+        examples=[False],
+    )
     special: bool | None = Field(
         default=None,
         description="(Privileged) This user has been given the Special role.",

--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -1,6 +1,7 @@
 """The base classes for all AI Horde API requests/responses."""
 from __future__ import annotations
 
+import os
 import random
 import uuid
 
@@ -112,7 +113,9 @@ class ImageGenerateParamMixin(BaseModel):
     v2 API Model: `ModelPayloadStable`
     """
 
-    model_config = ConfigDict(frozen=True)  # , extra="forbid")
+    model_config = (
+        ConfigDict(frozen=True) if not os.getenv("TESTS_ONGOING") else ConfigDict(frozen=True, extra="forbid")
+    )
 
     sampler_name: KNOWN_SAMPLERS | str = KNOWN_SAMPLERS.k_lms
     """The sampler to use for this generation. Defaults to `KNOWN_SAMPLERS.k_lms`."""

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import abc
+import os
 import uuid
 
 from loguru import logger
@@ -46,7 +47,9 @@ class HordeResponse(HordeAPIMessage):
 
 
 class HordeResponseBaseModel(HordeResponse, BaseModel):
-    model_config = ConfigDict(frozen=True)  # , extra="forbid")
+    model_config = (
+        ConfigDict(frozen=True) if not os.getenv("TESTS_ONGOING") else ConfigDict(frozen=True, extra="forbid")
+    )
 
 
 class ResponseRequiringFollowUpMixin(abc.ABC):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude = ["codegen"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
+"conftest.py" = ["E402"]
 
 [tool.black]
 line-length = 119

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pathlib
 
 import pytest
 
+os.environ["TESTS_ONGOING"] = "1"
+
 from horde_sdk.ai_horde_api.apimodels import ImageGenerateAsyncRequest, ImageGenerationInputPayload
 from horde_sdk.generic_api.consts import ANON_API_KEY
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ from horde_sdk.ai_horde_api.apimodels import ImageGenerateAsyncRequest, ImageGen
 from horde_sdk.generic_api.consts import ANON_API_KEY
 
 
+@pytest.fixture(scope="session", autouse=True)
+def check_tests_ongoing_env_var() -> None:
+    """Checks that the TESTS_ONGOING environment variable is set."""
+    assert os.getenv("TESTS_ONGOING", None) is not None, "TESTS_ONGOING environment variable not set"
+
+
 @pytest.fixture(scope="session")
 def ai_horde_api_key() -> str:
     dev_key = os.getenv("AI_HORDE_DEV_APIKEY", None)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ skip_empty = True
 description = base evironment
 passenv =
     AIWORKER_CACHE_HOME
+    TESTS_ONGOING
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
- This changes the default behavior of tests to forbid undefined fields in the objects returned from the API. This change aims to ensure that when SDK versions are published, they account for all of the currently defined objects and fields on the API.
- Incidentally, this PR also brings the SDK model definitions which do exist into compliance with the schema currently on the API, specifically the FindUserResponse model.