### PR TITLE
fix: make `bridge_version` optional for dreamer job pop

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -165,7 +165,7 @@ class ImageGenerateJobPopRequest(BaseAIHordeRequest, APIKeyAllowedInRequestMixin
     priority_usernames: list[str] = Field(default_factory=list)
     nsfw: bool = True
     models: list[str]
-    bridge_version: int
+    bridge_version: int | None = None
     bridge_agent: str
     threads: int = 1
     require_upfront_kudos: bool = False


### PR DESCRIPTION
`bridge_version` is deprecated. See https://github.com/Haidra-Org/AI-Horde/pull/338 for the API change for semver support (passed as the second element in the `bridge_agent` field).