### PR TITLE
fix: allow `all models` meta model load command

### DIFF
--- a/horde_sdk/ai_horde_worker/bridge_data.py
+++ b/horde_sdk/ai_horde_worker/bridge_data.py
@@ -19,7 +19,7 @@ _UNREASONABLE_NUMBER_OF_MODELS = 1000
 
 
 class MetaInstruction(StrEnum):
-    ALL_REGEX = r"all$"
+    ALL_REGEX = r"all$|all models+$"
 
     TOP_N_REGEX = r"TOP (\d+)"
     """The regex to use to match the top N models. The number is in a capture group on its own."""


### PR DESCRIPTION
This is for config file backward compatibility with `AI-Horde-Worker`