### PR TITLE
feat: more props. for `ImageGenerateJobPopResponse`; show more warnings on unknown field values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
     -    id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/horde_sdk/ai_horde_api/__init__.py
+++ b/horde_sdk/ai_horde_api/__init__.py
@@ -28,6 +28,7 @@ from horde_sdk.ai_horde_api.exceptions import (
     AIHordeRequestError,
     AIHordeServerException,
 )
+from horde_sdk.ai_horde_api.fields import ImageID, JobID, TeamID, WorkerID
 
 __all__ = [
     "AIHordeAPIManualClient",
@@ -50,4 +51,8 @@ __all__ = [
     "AIHordeGenerationTimedOutError",
     "AIHordeServerException",
     "AIHordePayloadValidationError",
+    "ImageID",
+    "JobID",
+    "TeamID",
+    "WorkerID",
 ]

--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -10,7 +10,7 @@ from horde_sdk.ai_horde_api.apimodels.base import (
     ImageGenerateParamMixin,
 )
 from horde_sdk.ai_horde_api.apimodels.generate._submit import ImageGenerationJobSubmitRequest
-from horde_sdk.ai_horde_api.consts import GENERATION_STATE, KNOWN_SOURCE_PROCESSING
+from horde_sdk.ai_horde_api.consts import GENERATION_STATE, KNOWN_SOURCE_PROCESSING, KNOWN_UPSCALERS
 from horde_sdk.ai_horde_api.endpoints import AI_HORDE_API_ENDPOINT_SUBPATH
 from horde_sdk.ai_horde_api.fields import JobID
 from horde_sdk.consts import HTTPMethod
@@ -157,6 +157,14 @@ class ImageGenerateJobPopResponse(HordeResponseBaseModel, ResponseRequiringFollo
             return True
 
         return super().ignore_failure()
+
+    @property
+    def has_upscaler(self) -> bool:
+        """Whether or not this image generation has an upscaler."""
+        if len(self.payload.post_processing) == 0:
+            return False
+
+        return any(post_processing in KNOWN_UPSCALERS.__members__ for post_processing in self.payload.post_processing)
 
 
 class ImageGenerateJobPopRequest(BaseAIHordeRequest, APIKeyAllowedInRequestMixin):

--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -10,7 +10,12 @@ from horde_sdk.ai_horde_api.apimodels.base import (
     ImageGenerateParamMixin,
 )
 from horde_sdk.ai_horde_api.apimodels.generate._submit import ImageGenerationJobSubmitRequest
-from horde_sdk.ai_horde_api.consts import GENERATION_STATE, KNOWN_SOURCE_PROCESSING, KNOWN_UPSCALERS
+from horde_sdk.ai_horde_api.consts import (
+    GENERATION_STATE,
+    KNOWN_FACEFIXERS,
+    KNOWN_SOURCE_PROCESSING,
+    KNOWN_UPSCALERS,
+)
 from horde_sdk.ai_horde_api.endpoints import AI_HORDE_API_ENDPOINT_SUBPATH
 from horde_sdk.ai_horde_api.fields import JobID
 from horde_sdk.consts import HTTPMethod
@@ -165,6 +170,14 @@ class ImageGenerateJobPopResponse(HordeResponseBaseModel, ResponseRequiringFollo
             return False
 
         return any(post_processing in KNOWN_UPSCALERS.__members__ for post_processing in self.payload.post_processing)
+
+    @property
+    def has_facefixer(self) -> bool:
+        """Whether or not this image generation has a facefixer."""
+        if len(self.payload.post_processing) == 0:
+            return False
+
+        return any(post_processing in KNOWN_FACEFIXERS.__members__ for post_processing in self.payload.post_processing)
 
 
 class ImageGenerateJobPopRequest(BaseAIHordeRequest, APIKeyAllowedInRequestMixin):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,8 @@
 pytest==7.4.4
 mypy==1.8.0
 black==23.12.1
-ruff==0.1.12
-tox~=4.12.0
+ruff==0.1.14
+tox~=4.12.1
 pre-commit~=3.6.0
 build>=0.10.0
 coverage>=7.2.7

--- a/tests/ai_horde_api/test_ai_horde_api_models.py
+++ b/tests/ai_horde_api/test_ai_horde_api_models.py
@@ -323,6 +323,7 @@ def test_ImageGenerateJobPopResponse() -> None:
 
     assert test_response.id_ is None
     assert test_response.has_upscaler is True
+    assert test_response.has_facefixer is False
 
     test_response = ImageGenerateJobPopResponse(
         id=None,
@@ -333,8 +334,8 @@ def test_ImageGenerateJobPopResponse() -> None:
         skipped=ImageGenerateJobPopSkippedStatus(),
     )
 
-    assert test_response.id_ is None
     assert test_response.has_upscaler is False
+    assert test_response.has_facefixer is False
 
     test_response = ImageGenerateJobPopResponse(
         id=None,
@@ -346,5 +347,18 @@ def test_ImageGenerateJobPopResponse() -> None:
         skipped=ImageGenerateJobPopSkippedStatus(),
     )
 
-    assert test_response.id_ is None
     assert test_response.has_upscaler is False
+    assert test_response.has_facefixer is True
+
+    test_response = ImageGenerateJobPopResponse(
+        id=None,
+        ids=[JobID(root=UUID("00000000-0000-0000-0000-000000000000"))],
+        payload=ImageGenerateJobPopPayload(
+            post_processing=[KNOWN_FACEFIXERS.CodeFormers, KNOWN_UPSCALERS.RealESRGAN_x2plus],
+            prompt="A cat in a hat",
+        ),
+        skipped=ImageGenerateJobPopSkippedStatus(),
+    )
+
+    assert test_response.has_upscaler is True
+    assert test_response.has_facefixer is True

--- a/tests/ai_horde_api/test_ai_horde_api_models.py
+++ b/tests/ai_horde_api/test_ai_horde_api_models.py
@@ -362,3 +362,15 @@ def test_ImageGenerateJobPopResponse() -> None:
 
     assert test_response.has_upscaler is True
     assert test_response.has_facefixer is True
+
+    test_response = ImageGenerateJobPopResponse(
+        id=None,
+        ids=[JobID(root=UUID("00000000-0000-0000-0000-000000000000"))],
+        payload=ImageGenerateJobPopPayload(
+            post_processing=["unknown post processor"],
+            control_type="unknown control type",
+            sampler_name="unknown sampler",
+            prompt="A cat in a hat",
+        ),
+        skipped=ImageGenerateJobPopSkippedStatus(),
+    )

--- a/tests/ai_horde_api/test_ai_horde_api_models.py
+++ b/tests/ai_horde_api/test_ai_horde_api_models.py
@@ -1,4 +1,6 @@
 """Unit tests for AI-Horde API models."""
+from uuid import UUID
+
 from horde_sdk.ai_horde_api.apimodels._find_user import (
     ContributionsDetails,
     FindUserRequest,
@@ -10,6 +12,11 @@ from horde_sdk.ai_horde_api.apimodels.generate._async import (
     ImageGenerateAsyncRequest,
     ImageGenerationInputPayload,
 )
+from horde_sdk.ai_horde_api.apimodels.generate._pop import (
+    ImageGenerateJobPopPayload,
+    ImageGenerateJobPopResponse,
+    ImageGenerateJobPopSkippedStatus,
+)
 from horde_sdk.ai_horde_api.apimodels.workers._workers_all import (
     AllWorkersDetailsResponse,
     TeamDetailsLite,
@@ -17,12 +24,15 @@ from horde_sdk.ai_horde_api.apimodels.workers._workers_all import (
     WorkerKudosDetails,
 )
 from horde_sdk.ai_horde_api.consts import (
+    KNOWN_FACEFIXERS,
     KNOWN_SAMPLERS,
     KNOWN_SOURCE_PROCESSING,
+    KNOWN_UPSCALERS,
     METADATA_TYPE,
     METADATA_VALUE,
     WORKER_TYPE,
 )
+from horde_sdk.ai_horde_api.fields import JobID
 
 
 def test_api_endpoint() -> None:
@@ -298,3 +308,43 @@ def test_GenMetadataEntry() -> None:
         type="test key",
         value="test value",
     )
+
+
+def test_ImageGenerateJobPopResponse() -> None:
+    test_response = ImageGenerateJobPopResponse(
+        id=None,
+        ids=[JobID(root=UUID("00000000-0000-0000-0000-000000000000"))],
+        payload=ImageGenerateJobPopPayload(
+            post_processing=[KNOWN_UPSCALERS.RealESRGAN_x2plus],
+            prompt="A cat in a hat",
+        ),
+        skipped=ImageGenerateJobPopSkippedStatus(),
+    )
+
+    assert test_response.id_ is None
+    assert test_response.has_upscaler is True
+
+    test_response = ImageGenerateJobPopResponse(
+        id=None,
+        ids=[JobID(root=UUID("00000000-0000-0000-0000-000000000000"))],
+        payload=ImageGenerateJobPopPayload(
+            prompt="A cat in a hat",
+        ),
+        skipped=ImageGenerateJobPopSkippedStatus(),
+    )
+
+    assert test_response.id_ is None
+    assert test_response.has_upscaler is False
+
+    test_response = ImageGenerateJobPopResponse(
+        id=None,
+        ids=[JobID(root=UUID("00000000-0000-0000-0000-000000000000"))],
+        payload=ImageGenerateJobPopPayload(
+            post_processing=[KNOWN_FACEFIXERS.CodeFormers],
+            prompt="A cat in a hat",
+        ),
+        skipped=ImageGenerateJobPopSkippedStatus(),
+    )
+
+    assert test_response.id_ is None
+    assert test_response.has_upscaler is False


### PR DESCRIPTION
- `has_upscaler` and `has_facefixer` properties for `ImageGenerateJobPopResponse`
  - This should be in the continued sprit of separating concerns from the worker code when API changes happen.
- Will now print a warning when a currently unknown `control_type` or `post_processor` is passed.