### PR TITLE
fix: allow SDK to handle the Horde rc

### DIFF
--- a/codegen/ai_horde_codegen_10072023.py
+++ b/codegen/ai_horde_codegen_10072023.py
@@ -944,6 +944,7 @@ class RequestAsync(BaseModel):
 
 class RequestError(BaseModel):
     message: str | None = Field(None, description="The error message for this status code.")
+    rc: str | None = Field(None, description="The return code for this status code")
 
 
 class RequestInterrogationResponse(BaseModel):

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -204,7 +204,7 @@ class ResponseWithProgressMixin(BaseModel):
 
 
 class ContainsMessageResponseMixin(BaseModel):
-    """Represents any response from any Horde API which contains a message."""
+    """Represents any response from any Horde API which contains a message and an rc."""
 
     message: str = ""
     rc: str = ""

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -207,6 +207,7 @@ class ContainsMessageResponseMixin(BaseModel):
     """Represents any response from any Horde API which contains a message."""
 
     message: str = ""
+    rc: str = ""
 
 
 class RequestErrorResponse(HordeResponseBaseModel, ContainsMessageResponseMixin):

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -244,7 +244,7 @@ class BaseHordeAPIClient(ABC):
         # If requests response is a failure code, see if a `message` key exists in the response.
         # If so, return a RequestErrorResponse
         if returned_status_code >= 400:
-            if len(raw_response_json) == 1 and "message" in raw_response_json:
+            if "rc" in raw_response_json:
                 return RequestErrorResponse(**raw_response_json)
 
             if "errors" in raw_response_json:

--- a/tests/ai_horde_api/test_ai_horde_api_models.py
+++ b/tests/ai_horde_api/test_ai_horde_api_models.py
@@ -1,6 +1,8 @@
 """Unit tests for AI-Horde API models."""
 from uuid import UUID
 
+import pytest
+
 from horde_sdk.ai_horde_api.apimodels._find_user import (
     ContributionsDetails,
     FindUserRequest,
@@ -418,3 +420,25 @@ def test_ImageGenerateJobPopResponse() -> None:
         ),
         skipped=ImageGenerateJobPopSkippedStatus(),
     )
+
+
+def test_error_response() -> None:
+    """Test that an error response can be parsed correctly."""
+    from horde_sdk.ai_horde_api.ai_horde_clients import (
+        AIHordeAPIManualClient,
+    )
+    from horde_sdk.generic_api.apimodels import RequestErrorResponse
+
+    client = AIHordeAPIManualClient()
+
+    api_request = FindUserRequest(apikey="1234567890123456789012")
+
+    api_response = client.submit_request(
+        api_request,
+        api_request.get_default_success_response_type(),
+    )
+
+    if isinstance(api_response, RequestErrorResponse):
+        assert not api_response.message.startswith("The response type doesn't match expected one!")
+    else:
+        pytest.fail(f"API Response was not an error: {api_response}")


### PR DESCRIPTION
When returning errors, the horde now also sends back an `rc` along with the `message`. This appears to cause the SDK to barf

```
horde_sdk.ai_horde_api.exceptions.AIHordeRequestError: The response type doesn't match expected one! See `object_data` for the raw response.
```

This is an attempt to handle the rc returned.