### PR TITLE
feat: allow latest `horde_model_reference` versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-horde_model_reference~=0.5.4
+horde_model_reference~=0.6.1
 
 pydantic
 requests


### PR DESCRIPTION
The compatibility version pin is unnecessary for the SDK.