### PR TITLE
feat: more model meta instructions + allow meta in skip models; fix: allow unknown alchemy types

### DIFF
--- a/horde_sdk/ai_horde_api/ai_horde_clients.py
+++ b/horde_sdk/ai_horde_api/ai_horde_clients.py
@@ -1025,6 +1025,7 @@ class AIHordeAPIAsyncSimpleClient(BaseAIHordeSimpleClient):
         image_gen_request: ImageGenerateAsyncRequest,
         timeout: int = GENERATION_MAX_LIFE,
         check_callback: Callable[[ImageGenerateCheckResponse], None] | None = None,
+        delay: float = 0.0,
     ) -> tuple[ImageGenerateStatusResponse, JobID]:
         """Submit an image generation request to the AI-Horde API, and wait for it to complete.
 
@@ -1043,6 +1044,8 @@ class AIHordeAPIAsyncSimpleClient(BaseAIHordeSimpleClient):
         Raises:
             AIHordeRequestError: If the request failed. The error response is included in the exception.
         """
+
+        await asyncio.sleep(delay)
 
         timeout = self.validate_timeout(timeout, log_message=True)
 

--- a/horde_sdk/ai_horde_api/apimodels/alchemy/_async.py
+++ b/horde_sdk/ai_horde_api/apimodels/alchemy/_async.py
@@ -71,7 +71,7 @@ class AlchemyAsyncRequestFormItem(HordeAPIDataObject):
     def check_name(cls, v: KNOWN_ALCHEMY_TYPES | str) -> KNOWN_ALCHEMY_TYPES | str:
         if isinstance(v, KNOWN_ALCHEMY_TYPES):
             return v
-        if isinstance(v, str) and v not in KNOWN_ALCHEMY_TYPES.__members__:
+        if str(v) not in KNOWN_ALCHEMY_TYPES.__members__:
             logger.warning(f"Unknown alchemy form name {v}. Is your SDK out of date or did the API change?")
         return v
 
@@ -83,8 +83,8 @@ class AlchemyAsyncRequest(
     forms: list[AlchemyAsyncRequestFormItem]
     source_image: str
     """The public URL of the source image or a base64 string to use."""
-    slow_workers: bool = False
-    """Whether to use the slower workers. Costs additional kudos if `True`."""
+    slow_workers: bool = True
+    """Whether to use the slower workers. Costs additional kudos if `False`."""
 
     @field_validator("forms")
     def check_at_least_one_form(cls, v: list[AlchemyAsyncRequestFormItem]) -> list[AlchemyAsyncRequestFormItem]:

--- a/horde_sdk/ai_horde_api/apimodels/alchemy/_status.py
+++ b/horde_sdk/ai_horde_api/apimodels/alchemy/_status.py
@@ -71,9 +71,7 @@ class AlchemyFormStatus(HordeAPIDataObject):
     def validate_form(cls, v: str | KNOWN_ALCHEMY_TYPES) -> KNOWN_ALCHEMY_TYPES | str:
         if isinstance(v, KNOWN_ALCHEMY_TYPES):
             return v
-        if (isinstance(v, str) and v not in KNOWN_ALCHEMY_TYPES.__members__) or (
-            not isinstance(v, KNOWN_ALCHEMY_TYPES)
-        ):
+        if str(v) not in KNOWN_ALCHEMY_TYPES.__members__:
             logger.warning(f"Unknown form type {v}. Is your SDK out of date or did the API change?")
         return v
 

--- a/horde_sdk/ai_horde_worker/model_meta.py
+++ b/horde_sdk/ai_horde_worker/model_meta.py
@@ -2,6 +2,7 @@ import re
 
 from horde_model_reference.meta_consts import MODEL_REFERENCE_CATEGORY
 from horde_model_reference.model_reference_manager import ModelReferenceManager
+from horde_model_reference.model_reference_records import StableDiffusion_ModelRecord
 from loguru import logger
 
 from horde_sdk.ai_horde_api.ai_horde_clients import AIHordeAPIManualClient
@@ -111,6 +112,35 @@ class ImageModelLoadResolver:
 
         logger.error("No stable diffusion models found in model reference.")
         return set()
+
+    def resolve_all_models_of_baseline(self, baseline: str) -> set[str]:
+        """Get the names of all models of a given baseline defined in the model reference.
+
+        Args:
+            baseline: A string representing the baseline to get models for.
+
+        Returns:
+            A set of strings representing the names of all models of the given baseline.
+        """
+        all_model_references = self._model_reference_manager.get_all_model_references()
+
+        sd_model_references = all_model_references[MODEL_REFERENCE_CATEGORY.stable_diffusion]
+
+        found_models: set[str] = set()
+
+        if sd_model_references is None:
+            logger.error("No stable diffusion models found in model reference.")
+            return found_models
+
+        for model in sd_model_references.root.values():
+            if not isinstance(model, StableDiffusion_ModelRecord):
+                logger.error(f"Model {model} is not a StableDiffusion_ModelRecord")
+                continue
+
+            if model.baseline == baseline:
+                found_models.add(model.name)
+
+        return found_models
 
     @staticmethod
     def resolve_top_n_model_names(

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -375,7 +375,7 @@ class RequestUsesImageWorkerMixin(BaseModel):
     """Mix-in class to describe an endpoint for which you can specify workers."""
 
     trusted_workers: bool = False
-    slow_workers: bool = False
+    slow_workers: bool = True
     workers: list[str] = Field(default_factory=list)
     worker_blacklist: list[str] = Field(default_factory=list)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-horde_model_reference~=0.6.1
+horde_model_reference~=0.6.3
 
 pydantic
 requests

--- a/tests/ai_horde_worker/test_model_meta.py
+++ b/tests/ai_horde_worker/test_model_meta.py
@@ -93,6 +93,81 @@ def test_image_model_load_resolver_multiple_instructions(
     assert len(resolved_model_names) == 2
 
 
+def test_image_model_load_resolved_all_sd15(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all sd15"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+
+    for model_name in resolved_model_names:
+        assert "SDXL" not in model_name
+
+    assert "Deliberate" in resolved_model_names
+
+
+def test_image_model_load_resolved_all_sd21(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all sd21"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+
+    for model_name in resolved_model_names:
+        assert "SDXL" not in model_name
+        assert model_name != "Deliberate"
+
+
+def test_image_model_load_resolved_all_sdxl(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all sdxl"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+    assert "AlbedoBase XL (SDXL)" in resolved_model_names
+
+
+def test_image_model_load_resolved_all_inpainting(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all inpainting"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+    assert any("inpainting" in model_name.lower() for model_name in resolved_model_names)
+
+
+def test_image_model_load_resolved_sfw_nsfw(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all sfw"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+    assert not any("urpm" in model_name.lower() for model_name in resolved_model_names)
+
+    resolved_model_names = image_model_load_resolver.resolve_meta_instructions(
+        ["all nsfw"],
+        AIHordeAPIManualClient(),
+    )
+
+    assert len(resolved_model_names) > 0
+    assert any("urpm" in model_name.lower() for model_name in resolved_model_names)
+
+
 def test_image_models_unique_results_only(
     image_model_load_resolver: ImageModelLoadResolver,
 ) -> None:

--- a/tests/ai_horde_worker/test_model_meta.py
+++ b/tests/ai_horde_worker/test_model_meta.py
@@ -103,3 +103,11 @@ def test_image_models_unique_results_only(
     all_model_names = image_model_load_resolver.resolve_all_model_names()
 
     assert len(resolved_model_names) >= (len(all_model_names) - 1)  # FIXME: -1 is to account for SDXL beta
+
+
+def test_resolve_all_models_of_baseline(
+    image_model_load_resolver: ImageModelLoadResolver,
+) -> None:
+    resolved_model_names = image_model_load_resolver.resolve_all_models_of_baseline("stable_diffusion_xl")
+
+    assert len(resolved_model_names) > 0


### PR DESCRIPTION
- Meta load commands are now supported in for `models_to_skip`
- `ALL SDXL`, `ALL SD15`, `ALL SD21`, `ALL SFW`, `ALL NSFW` are now all valid model meta load (or skip) instructions.
- An oversight led to warnings being generated during alchemy generate requests. This has been corrected.