### PR TITLE
fix: post remix bug fixes; don't crash on client usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ out.json
 
 examples/requested_images/*.*
 _version.py
+
+tests/testing_result_images/*
+!tests/testing_result_images/.results_go_here

--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -132,7 +132,7 @@ class ExtraSourceImageEntry(HordeAPIDataObject):
     """
 
     image: str = Field(min_length=1)
-    """The URL of the image to download."""
+    """The URL of the image to download, or the base64 string once downloaded."""
     strength: float = Field(default=1, ge=-5, le=5)
     """The strength to apply to this image on various operations."""
 

--- a/horde_sdk/ai_horde_api/apimodels/generate/_async.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_async.py
@@ -179,4 +179,4 @@ class ImageGenerateAsyncRequest(
 
     @override
     def get_extra_fields_to_exclude_from_log(self) -> set[str]:
-        return {"source_image"}
+        return {"source_image", "source_mask", "extra_source_images"}

--- a/horde_sdk/ai_horde_api/apimodels/generate/_async.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_async.py
@@ -38,7 +38,7 @@ class ImageGenerateAsyncResponse(
 
     """The UUID for this image generation."""
     kudos: float
-    warnings: list[SingleWarningEntry]
+    warnings: list[SingleWarningEntry] | None = None
 
     @override
     def get_follow_up_returned_params(self, *, as_python_field_name: bool = False) -> list[dict[str, object]]:

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from abc import ABC
 from typing import TypeVar
 
@@ -110,6 +111,10 @@ class BaseHordeAPIClient(ABC):
 
         if not self._apikey:
             self._apikey = ANON_API_KEY
+
+        if os.getenv("AI_HORDE_DEV_APIKEY"):
+            logger.warning("Using the AI Horde API key from the environment variable `AI_HORDE_DEV_APIKEY`.")
+            self._apikey = os.getenv("AI_HORDE_DEV_APIKEY")
 
         if not issubclass(header_fields, GenericHeaderFields):  # pragma: no cover
             raise TypeError("`header_fields` must be of type `GenericHeaderData` or a subclass of it!")


### PR DESCRIPTION
- [An oversight](484e04a4afdd91fe0424d95cc95ea5218dbf6e34) led to most client requests crashing the SDK. This has been fixed.
- `ImageGenerateJobPopResponse` (and in the future, any child class of `ResponseRequiringDownloadMixin`) can now support (asynchronously) downloading the `source_image`, `source_mask` and `extra_source_images` fields in the SDK.
  - This is part of the continued effort of de-coupling the worker from the SDK wherever possible.
- A few minor fixes, such as not logging base64 image information to the log, and using `AI_HORDE_DEV_APIKEY` as the default API key when it is set.