### PR TITLE
feat: handle extra image retries

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -131,6 +131,9 @@ class ExtraSourceImageEntry(HordeAPIDataObject):
     v2 API Model: `ExtraSourceImage`
     """
 
+    original_url: str | None = None
+    """The URL of the original image after it was downloaded."""
+
     image: str = Field(min_length=1)
     """The URL of the image to download, or the base64 string once downloaded."""
     strength: float = Field(default=1, ge=-5, le=5)

--- a/tests/ai_horde_api/test_ai_horde_api_models.py
+++ b/tests/ai_horde_api/test_ai_horde_api_models.py
@@ -648,6 +648,10 @@ async def test_ImageGenerateJobPop_download_addtl_data() -> None:
     assert len(downloaded_extra_source_images) == 2
     for extra_source_image in downloaded_extra_source_images:
         assert extra_source_image is not None
+        assert extra_source_image.original_url is not None
+        assert extra_source_image.original_url.startswith(
+            "https://raw.githubusercontent.com/db0/Stable-Horde/main/img_stable/",
+        )
         assert PIL.Image.open(io.BytesIO(base64.b64decode(extra_source_image.image)))
 
     assert downloaded_extra_source_images[0].strength == 1.0


### PR DESCRIPTION
This helps decouple a potential headache from having to be handled by the worker in the case of extra images failing to download.