### PR TITLE
fix: support pydantic 2.7.0; chore: conform with new ruff pyproject.toml section format

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/workers/_workers_all.py
+++ b/horde_sdk/ai_horde_api/apimodels/workers/_workers_all.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
-from typing import ClassVar
 
-from pydantic import AliasChoices, ConfigDict, Field, RootModel
+from pydantic import AliasChoices, Field, RootModel
 from typing_extensions import override
 
 from horde_sdk.ai_horde_api.apimodels.base import BaseAIHordeRequest
@@ -130,8 +129,6 @@ class WorkerDetailItem(HordeAPIObject):
 
 
 class AllWorkersDetailsResponse(HordeResponse, RootModel[list[WorkerDetailItem]]):
-    model_config: ClassVar[ConfigDict] = {}
-
     # @tazlin: The typing of __iter__ in BaseModel seems to assume that RootModel wouldn't also be a parent class.
     # without a `type: ignore``, mypy feels that this is a bad override. This is probably a sub-optimal solution
     # on my part with me hoping to come up with a more elegant path in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ tests = ["*.json"]
 
 [tool.ruff]
 line-length = 119
+exclude = ["codegen"]
+
+[tool.ruff.lint]
 select = [
   "A",
   "I",
@@ -70,9 +73,8 @@ ignore = [
   "D408",
   "D409",
   "D413",]
-exclude = ["codegen"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402"]
 "conftest.py" = ["E402"]
 


### PR DESCRIPTION
- Removes a long-forgotten about attr in `AllWorkersDetailsResponse` which now causes a breaking runtime exception with `pydantic` 2.7.0.
- Silences warnings about soon to be deprecated `ruff` configuration sections in `pyproject.toml`.