### PR TITLE
ci: test python 3.11 too

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -38,5 +38,7 @@ jobs:
           pip install --upgrade -r requirements.dev.txt
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
       - name: Run unit tests
         run: tox -e tests-no-api-calls

--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -43,5 +43,7 @@ jobs:
           pip install --upgrade -r requirements.dev.txt
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
       - name: Run unit tests
         run: tox -e tests-no-api-calls

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This brings this repo in line with the standard expectation of support for at least python 3.11.