### PR TITLE
docs: removes `_version.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ out.json
 
 examples/requested_images/*.*
 _version.py
+_version.md # to prevent mkdocs from including this file in the documentation
 
 tests/testing_result_images/*
 !tests/testing_result_images/.results_go_here

--- a/docs/horde_sdk/_version.md
+++ b/docs/horde_sdk/_version.md
@@ -1,2 +1,0 @@
-# _version
-::: horde_sdk._version


### PR DESCRIPTION
This is not a documentable object and would not appear in the repo/docs under ordinary circumstances.