### PR TITLE
tests: api side worker test; fix: misc fixes

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -19,8 +19,9 @@ jobs:
   build:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache
-      HORDE_MODEL_REFERENCE_MAKE_FOLDERS: 1
       TESTS_ONGOING: 1
+      HORDE_SDK_TESTING: 1
+      HORDE_MODEL_REFERENCE_MAKE_FOLDERS: 1
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       AIWORKER_CACHE_HOME: ${{ github.workspace }}/.cache
       TESTS_ONGOING: 1
+      HORDE_SDK_TESTING: 1
       HORDE_MODEL_REFERENCE_MAKE_FOLDERS: 1
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,13 @@ repos:
         pass_filenames: false
         additional_dependencies: [
             pytest,
-            pydantic,
+            pydantic==2.7.4,
             types-Pillow,
             types-requests,
             types-pytz,
             types-setuptools,
             types-urllib3,
             types-aiofiles,
-            StrEnum
+            StrEnum,
+            horde_model_reference==0.8.1,
         ]

--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -219,7 +219,7 @@ class ImageGenerateParamMixin(HordeAPIDataObject):
     karras: bool = True
     """Set to True if you want to use the Karras scheduling."""
     tiling: bool = False
-    """Deprecated."""
+    """Set to True if you want to use seamless tiling."""
     hires_fix: bool = False
     """Set to True if you want to use the hires fix."""
     hires_fix_denoising_strength: float | None = Field(default=None, ge=0, le=1)
@@ -234,17 +234,17 @@ class ImageGenerateParamMixin(HordeAPIDataObject):
     """Set to True if you want the ControlNet map returned instead of a generated image."""
     facefixer_strength: float | None = Field(default=None, ge=0, le=1)
     """The strength of the facefixer model."""
-    loras: list[LorasPayloadEntry] = Field(default_factory=list)
+    loras: list[LorasPayloadEntry] | None = None
     """A list of lora parameters to use."""
-    tis: list[TIPayloadEntry] = Field(default_factory=list)
+    tis: list[TIPayloadEntry] | None = None
     """A list of textual inversion (embedding) parameters to use."""
-    extra_texts: list[ExtraTextEntry] = Field(default_factory=list)
+    extra_texts: list[ExtraTextEntry] | None = None
     """A list of extra texts and prompts to use in the comfyUI workflow."""
     workflow: str | KNOWN_WORKFLOWS | None = None
     """The specific comfyUI workflow to use."""
     transparent: bool | None = None
     """When true, will generate an image with a transparent background"""
-    special: dict[Any, Any] = Field(default_factory=dict)
+    special: dict[Any, Any] | None = None
     """Reserved for future use."""
     use_nsfw_censor: bool = False
     """If the request is SFW, and the worker accidentally generates NSFW, it will send back a censored image."""

--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -418,11 +418,9 @@ class PopInput(HordeAPIObject):
         max_length=1000,
     )
     """The worker name, version and website."""
-    models: list[str] | None = None
+    models: list[str]
     """The models this worker can generate."""
-    name: str | None = Field(
-        None,
-    )
+    name: str
     """The Name of the Worker."""
     nsfw: bool | None = Field(
         False,

--- a/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
+++ b/horde_sdk/ai_horde_api/apimodels/generate/_pop.py
@@ -253,8 +253,15 @@ class ImageGenerateJobPopResponse(
 
         return v
 
+    _ids_present: bool = False
+
+    @property
+    def ids_present(self) -> bool:
+        """Whether or not the IDs are present."""
+        return self._ids_present
+
     @model_validator(mode="after")
-    def ids_present(self) -> ImageGenerateJobPopResponse:
+    def validate_ids_present(self) -> ImageGenerateJobPopResponse:
         """Ensure that either id_ or ids is present."""
         if self.model is None:
             if self.skipped.is_empty():
@@ -269,6 +276,8 @@ class ImageGenerateJobPopResponse(
         if len(self.ids) > 1:
             logger.debug("Sorting IDs")
             self.ids.sort()
+
+        self._ids_present = True
 
         return self
 

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -79,9 +79,14 @@ class HordeAPIMessage(HordeAPIObject):
         """Return an additional set of fields to exclude from the log_safe_model_dump method."""
         return set()
 
-    def log_safe_model_dump(self) -> dict[Any, Any]:
+    def log_safe_model_dump(self, extra_exclude: set[str] | None = None) -> dict[Any, Any]:
         """Return a dict of the model's fields, with any sensitive fields redacted."""
-        return self.model_dump(exclude=self.get_sensitive_fields() | self.get_extra_fields_to_exclude_from_log())
+        if extra_exclude is None:
+            extra_exclude = set()
+
+        return self.model_dump(
+            exclude=self.get_sensitive_fields() | self.get_extra_fields_to_exclude_from_log() | extra_exclude,
+        )
 
 
 class HordeResponse(HordeAPIMessage):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,9 @@ exclude = [
 concurrency = ["gevent"]
 
 [tool.pytest.ini_options]
+# You can use `and`, `or`, `not` and parentheses to filter with the `-m` option
 markers = [
-    # "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "object_verify: marks tests that verify the API object structure and layout",
+    "api_side_ci: indicates that the test is intended to run during CI for the API",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-horde_model_reference~=0.7.0
+horde_model_reference~=0.8.1
 
-pydantic
+pydantic==2.7.4
 requests
 StrEnum
 loguru

--- a/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
+++ b/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
@@ -1,47 +1,27 @@
 import asyncio
-import base64
-from typing import Any
 
 import aiohttp
 import PIL.Image
 import pytest
-from loguru import logger
 import yarl
+from loguru import logger
 
 from horde_sdk.ai_horde_api.ai_horde_clients import (
     AIHordeAPIAsyncClientSession,
     AIHordeAPIAsyncSimpleClient,
-    AIHordeAPISimpleClient,
 )
 from horde_sdk.ai_horde_api.apimodels import (
-    KNOWN_ALCHEMY_TYPES,
-    AlchemyAsyncRequest,
-    AlchemyAsyncRequestFormItem,
-    AlchemyStatusResponse,
     ImageGenerateAsyncRequest,
-    ImageGenerateAsyncResponse,
-    ImageGenerateCheckResponse,
-    ImageGenerateJobPopPayload,
     ImageGenerateJobPopRequest,
     ImageGenerateJobPopResponse,
-    ImageGenerateJobPopSkippedStatus,
     ImageGenerateStatusResponse,
-    ImageGenerationInputPayload,
     ImageGenerationJobSubmitRequest,
     JobSubmitResponse,
-    LorasPayloadEntry,
 )
-from horde_sdk.ai_horde_api.apimodels.base import ExtraSourceImageEntry
 from horde_sdk.ai_horde_api.consts import (
     GENERATION_STATE,
-    KNOWN_FACEFIXERS,
-    KNOWN_MISC_POST_PROCESSORS,
-    KNOWN_SOURCE_PROCESSING,
-    KNOWN_UPSCALERS,
-    POST_PROCESSOR_ORDER_TYPE,
 )
 from horde_sdk.ai_horde_api.fields import JobID
-from horde_sdk.generic_api.apimodels import RequestErrorResponse
 
 
 class TestImageWorkerRoundtrip:

--- a/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
+++ b/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
@@ -151,8 +151,9 @@ class TestImageWorkerRoundtrip:
             )
 
             assert isinstance(job_submit_response, JobSubmitResponse)
-
             assert job_submit_response.reward is not None and job_submit_response.reward > 0
+
+            break
 
     @pytest.mark.api_side_ci
     @pytest.mark.asyncio

--- a/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
+++ b/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
@@ -68,7 +68,7 @@ class TestImageWorkerRoundtrip:
         )
 
         assert isinstance(job_pop_response, ImageGenerateJobPopResponse)
-        logger.info(f"{job_pop_response.log_safe_model_dump()}")
+        logger.info(f"{job_pop_response.log_safe_model_dump({'skipped'})}")
 
         assert not job_pop_response.ids_present
         assert job_pop_response.skipped is not None
@@ -103,7 +103,8 @@ class TestImageWorkerRoundtrip:
             )
 
             assert isinstance(job_pop_response, ImageGenerateJobPopResponse)
-            logger.info(f"{job_pop_response.log_safe_model_dump()}")
+            logger.info(f"{job_pop_response.log_safe_model_dump({'skipped'})}")
+            logger.info(f"Checked in as fake worker ({effective_resolution}): {job_pop_response.skipped}")
 
             if not job_pop_response.ids_present:
                 if current_try >= max_tries:

--- a/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
+++ b/tests/ai_horde_api/test_ai_worker_roundtrip_api_calls.py
@@ -53,7 +53,7 @@ class TestImageWorkerRoundtrip:
     ) -> None:
         assert image_gen_request.params is not None
 
-        effective_resolution = image_gen_request.params.width * image_gen_request.params.height
+        effective_resolution = (image_gen_request.params.width * image_gen_request.params.height) * 2
 
         job_pop_request = ImageGenerateJobPopRequest(
             name="fake CI worker",
@@ -83,7 +83,7 @@ class TestImageWorkerRoundtrip:
     ) -> None:
         assert image_gen_request.params is not None
 
-        effective_resolution = image_gen_request.params.width * image_gen_request.params.height
+        effective_resolution = (image_gen_request.params.width * image_gen_request.params.height) * 2
 
         job_pop_request = ImageGenerateJobPopRequest(
             name="fake CI worker",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import base64
 import os
 import pathlib
 
-from loguru import logger
 import pytest
+from loguru import logger
 
 os.environ["TESTS_ONGOING"] = "1"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import base64
 import os
 import pathlib
 
+from loguru import logger
 import pytest
 
 os.environ["TESTS_ONGOING"] = "1"
@@ -14,6 +15,21 @@ from horde_sdk.generic_api.consts import ANON_API_KEY
 def check_tests_ongoing_env_var() -> None:
     """Checks that the TESTS_ONGOING environment variable is set."""
     assert os.getenv("TESTS_ONGOING", None) is not None, "TESTS_ONGOING environment variable not set"
+
+    AI_HORDE_TESTING = os.getenv("AI_HORDE_TESTING", None)
+    HORDE_SDK_TESTING = os.getenv("HORDE_SDK_TESTING", None)
+    if AI_HORDE_TESTING is None and HORDE_SDK_TESTING is None:
+        logger.warning(
+            "Neither AI_HORDE_TESTING nor HORDE_SDK_TESTING environment variables are set. "
+            "Is this a local development test run? If so, set AI_HORDE_TESTING=1 or HORDE_SDK_TESTING=1 to suppress "
+            "this warning",
+        )
+
+    if AI_HORDE_TESTING is not None:
+        logger.info("AI_HORDE_TESTING environment variable set.")
+
+    if HORDE_SDK_TESTING is not None:
+        logger.info("HORDE_SDK_TESTING environment variable set.")
 
 
 @pytest.fixture(scope="session")
@@ -30,7 +46,7 @@ def simple_image_gen_request(ai_horde_api_key: str) -> ImageGenerateAsyncRequest
         prompt="a cat in a hat",
         models=["Deliberate"],
         params=ImageGenerationInputPayload(
-            steps=1,
+            steps=5,
             n=1,
         ),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     requests
     -r requirements.txt
 commands =
-    pytest tests {posargs} --cov
+    pytest tests {posargs} --cov -m "not api_side_ci"
 
 
 [testenv:tests-no-api-calls]
@@ -50,4 +50,4 @@ deps =
     requests
     -r requirements.txt
 commands =
-    pytest tests {posargs} --ignore-glob=*api_calls.py --cov
+    pytest tests {posargs} --ignore-glob=*api_calls.py -m "not api_side_ci"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ skip_empty = True
 description = base evironment
 passenv =
     AIWORKER_CACHE_HOME
+    HORDE_SDK_TESTING
+    AI_HORDE_TESTING
     TESTS_ONGOING
 
 [testenv:pre-commit]


### PR DESCRIPTION
- An initial test designed for testing worker functionality of the API of AI-Horde during it's CI runs
- `validate_ids_present` now works as intended. ([fix: implement ids_present as intended](https://github.com/Haidra-Org/horde-sdk/commit/8097e567e555cd7d46f510a2ca64cc41bf80cfe1))
- Certain fields were defaulting to empty lists (or otherwise not `None`) despite the API not returning them. They now are unset (`None`) as intended (https://github.com/Haidra-Org/horde-sdk/commit/ea5e04c91c543d8c96fdb1ef03c084f48a289fea)