### PR TITLE
Feat: Allows to lookup single worker by name in the worker/ endpoint

### DIFF
--- a/horde_sdk/ai_horde_api/ai_horde_clients.py
+++ b/horde_sdk/ai_horde_api/ai_horde_clients.py
@@ -978,18 +978,20 @@ class AIHordeAPISimpleClient(BaseAIHordeSimpleClient):
     def worker_details(
         self,
         worker_id: WorkerID | str,
+        is_name: bool | None = None,
     ) -> SingleWorkerDetailsResponse:
         """Get the details for a worker.
 
         Args:
-            worker_id (WorkerID): The ID of the worker to get the details for.
+            worker_id (WorkerID or Worker name): The ID of the worker to get the details for.
+            is_name (bool): if the worker_id argument is the worker name, this needs to be set to true.
 
         Returns:
             SingleWorkerDetailsResponse: The response from the API.
         """
         with AIHordeAPIClientSession() as horde_session:
             response = horde_session.submit_request(
-                SingleWorkerDetailsRequest(worker_id=worker_id),
+                SingleWorkerDetailsRequest(worker_id=worker_id, is_name=is_name),
                 SingleWorkerDetailsResponse,
             )
 

--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -85,6 +85,13 @@ class WorkerRequestMixin(HordeAPIDataObject):
     """The UUID of the worker in question for this request."""
 
 
+class WorkerGetRequestMixin(HordeAPIDataObject):
+    """Mix-in class for data relating to worker GET requests."""
+
+    is_name: bool | None = Field(default=None)
+    """Whether the worker_id sent is be a worker name instead"""
+
+
 class LorasPayloadEntry(HordeAPIDataObject):
     """Represents a single lora parameter.
 

--- a/horde_sdk/ai_horde_api/apimodels/workers/_workers.py
+++ b/horde_sdk/ai_horde_api/apimodels/workers/_workers.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from pydantic import AliasChoices, Field, RootModel
 from typing_extensions import override
 
-from horde_sdk.ai_horde_api.apimodels.base import BaseAIHordeRequest, WorkerRequestMixin
+from horde_sdk.ai_horde_api.apimodels.base import BaseAIHordeRequest, WorkerGetRequestMixin, WorkerRequestMixin
 from horde_sdk.ai_horde_api.consts import WORKER_TYPE
 from horde_sdk.ai_horde_api.endpoints import AI_HORDE_API_ENDPOINT_SUBPATH
 from horde_sdk.ai_horde_api.fields import TeamID, WorkerID
@@ -239,7 +239,12 @@ class SingleWorkerDetailsResponse(HordeResponse, WorkerDetailItem):
         return "WorkerDetails"
 
 
-class SingleWorkerDetailsRequest(BaseAIHordeRequest, WorkerRequestMixin, APIKeyAllowedInRequestMixin):
+class SingleWorkerDetailsRequest(
+    BaseAIHordeRequest,
+    WorkerRequestMixin,
+    WorkerGetRequestMixin,
+    APIKeyAllowedInRequestMixin,
+):
     """Returns information on a single worker.
 
     If a moderator API key is specified, additional information is returned.


### PR DESCRIPTION
I added a new query arg on the `worker/` endpoint `is_name`. When true, it will do a seek as if `worker_id` is a worker name. However I have no idea how to declare this on the SDK. Here's the initial work I did so far