### PR TITLE
feat: use `pydantic==2.9.2`; chore: update dev deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,22 +6,22 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.6.5
     hooks:
     -    id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.0'
+    rev: 'v1.11.2'
     hooks:
     -   id: mypy
         args: [., --strict, --ignore-missing-imports, --exclude=^codegen]
         pass_filenames: false
         additional_dependencies: [
             pytest,
-            pydantic==2.7.4,
+            pydantic>=2.9.2,
             types-Pillow,
             types-requests,
             types-pytz,

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -325,7 +325,7 @@ class HordeRequest(HordeAPIMessage, BaseModel):
     # X_Fields # TODO
 
     client_agent: str = Field(
-        default=f"horde_sdk:{__version__}:https://githib.com/haidra-org/horde-sdk",
+        default=f"horde_sdk:{__version__}:https://github.com/haidra-org/horde-sdk",
         alias="Client-Agent",
     )
     """The requesting client's agent. You should set this to reflect the name, version and contact information

--- a/horde_sdk/horde_logging.py
+++ b/horde_sdk/horde_logging.py
@@ -21,30 +21,22 @@ def set_logger_verbosity(count: int) -> None:
 
 def is_stdout_log(record: dict[str, Any]) -> bool:
     """Filter for stdout logs levels."""
-    if record["level"].no < verbosity:
-        return False
-    return True
+    return not record["level"].no < verbosity
 
 
 def is_msg_log(record: dict[str, Any]) -> bool:
     """Filter for stdout logs levels."""
-    if record["level"].no < verbosity:
-        return False
-    return True
+    return not record["level"].no < verbosity
 
 
 def is_stderr_log(record: dict[str, Any]) -> bool:
     """Filter for stderr logs levels."""
-    if record["level"].name not in error_levels:
-        return False
-    return True
+    return not record["level"].name not in error_levels
 
 
 def is_trace_log(record: dict[str, Any]) -> bool:
     """Filter for trace logs levels."""
-    if record["level"].name not in error_levels:
-        return False
-    return True
+    return not record["level"].name not in error_levels
 
 
 handler_config = [

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,9 +1,9 @@
-pytest==8.2.1
-mypy==1.10.0
-black==24.4.2
-ruff==0.4.7
-tox~=4.15.0
-pre-commit~=3.7.1
+pytest==8.3.3
+mypy==1.11.2
+black==24.8.0
+ruff==0.6.5
+tox~=4.18.1
+pre-commit~=3.8.0
 build>=0.10.0
 coverage>=7.2.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 horde_model_reference>=0.9.0
 
-pydantic==2.7.4
+pydantic==2.9.2
 requests
 StrEnum
 loguru


### PR DESCRIPTION
- The most recent version of pydantic resolves some typing related issues to do with BaseModels, particularly for the `default` arg for `Field`.
- Fixes a typo in the default client agent string (thanks @Luke100000) 
- Updates all linting/formatting/ci dependencies with a corresponding non-functional change to the code in `horde_logging.py` to comply with the latest version of a ruff rule.