### PR TITLE
feat: remove large models from model meta commands

### DIFF
--- a/horde_sdk/__init__.py
+++ b/horde_sdk/__init__.py
@@ -51,6 +51,12 @@ def _dev_env_var_warnings() -> None:  # pragma: no cover
         if len(dev_key) != 10 and len(dev_key) != 22:
             raise ValueError("AI_HORDE_DEV_APIKEY must be the anon key or 22 characters long.")
 
+    AI_HORDE_MODEL_META_LARGE_MODELS = os.getenv("AI_HORDE_MODEL_META_LARGE_MODELS")
+    if AI_HORDE_MODEL_META_LARGE_MODELS:
+        logger.debug(
+            f"AI_HORDE_MODEL_META_LARGE_MODELS is {AI_HORDE_MODEL_META_LARGE_MODELS}.",
+        )
+
 
 _dev_env_var_warnings()
 

--- a/tests/ai_horde_worker/test_model_meta_api_calls.py
+++ b/tests/ai_horde_worker/test_model_meta_api_calls.py
@@ -29,6 +29,16 @@ def test_image_model_load_resolver_all(image_model_load_resolver: ImageModelLoad
 
     assert len(all_model_names) > 0
 
+    import os
+
+    os.environ["AI_HORDE_MODEL_META_LARGE_MODELS"] = "true"
+
+    all_model_names_with_large = image_model_load_resolver.resolve_all_model_names()
+
+    del os.environ["AI_HORDE_MODEL_META_LARGE_MODELS"]
+
+    assert len(all_model_names_with_large) > len(all_model_names)
+
 
 def test_image_model_load_resolver_top_n(
     image_model_load_resolver: ImageModelLoadResolver,
@@ -178,6 +188,19 @@ def test_image_models_unique_results_only(
     all_model_names = image_model_load_resolver.resolve_all_model_names()
 
     assert len(resolved_model_names) >= (len(all_model_names) - 1)  # FIXME: -1 is to account for SDXL beta
+
+    import os
+
+    os.environ["AI_HORDE_MODEL_META_LARGE_MODELS"] = "true"
+
+    resolved_models_names_with_large = image_model_load_resolver.resolve_meta_instructions(
+        ["top 1000", "bottom 1000"],
+        AIHordeAPIManualClient(),
+    )
+
+    del os.environ["AI_HORDE_MODEL_META_LARGE_MODELS"]
+
+    assert len(resolved_models_names_with_large) >= len(resolved_model_names)
 
 
 def test_resolve_all_models_of_baseline(


### PR DESCRIPTION
Controlled by `AI_HORDE_MODEL_META_LARGE_MODELS`. Any non-null value will allow very large models, such as cascade and flux, to be returned from model meta commands.