### PR TITLE
feat: Adds the exta information metadata key

### DIFF
--- a/codegen/ai_horde/swagger.json
+++ b/codegen/ai_horde/swagger.json
@@ -4214,7 +4214,8 @@
               "source_image",
               "source_mask",
               "extra_source_images",
-              "batch_index"
+              "batch_index",
+              "information"
             ]
           },
           "value": {

--- a/codegen/ai_horde/swagger_openapi3.json
+++ b/codegen/ai_horde/swagger_openapi3.json
@@ -5208,7 +5208,8 @@
               "source_image",
               "source_mask",
               "extra_source_images",
-              "batch_index"
+              "batch_index",
+              "information"
             ],
             "example": "lora",
             "type": "string"

--- a/horde_sdk/ai_horde_api/consts.py
+++ b/horde_sdk/ai_horde_api/consts.py
@@ -251,6 +251,8 @@ class METADATA_TYPE(StrEnum):
     """Extra source images for the request."""
     batch_index = auto()
     """The index of the batch in a batch request."""
+    information = auto()
+    """Extra information about the image."""
 
 
 class METADATA_VALUE(StrEnum):


### PR DESCRIPTION
New `information` key will hold whether the image is nsfw or not, but in the future is open ended enough to be expanded with `see_ref` with more arbitrary info if needed.

Necessary for https://github.com/Haidra-Org/AI-Horde/issues/442