### PR TITLE
fix: use a default `certifi` based ssl context

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -37,9 +37,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.dev.txt
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --all-files
       - name: Run unit tests
         run: tox -e tests-no-api-calls

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -42,9 +42,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.dev.txt
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --all-files
       - name: Run unit tests
         run: tox -e tests-no-api-calls

--- a/horde_sdk/ai_horde_api/ai_horde_clients.py
+++ b/horde_sdk/ai_horde_api/ai_horde_clients.py
@@ -10,8 +10,8 @@ import time
 import urllib.parse
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
-from typing import cast
 from ssl import SSLContext
+from typing import cast
 
 import aiohttp
 import PIL.Image

--- a/horde_sdk/ai_horde_api/ai_horde_clients.py
+++ b/horde_sdk/ai_horde_api/ai_horde_clients.py
@@ -11,6 +11,7 @@ import urllib.parse
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
 from typing import cast
+from ssl import SSLContext
 
 import aiohttp
 import PIL.Image
@@ -78,6 +79,7 @@ from horde_sdk.generic_api.generic_clients import (
     GenericAsyncHordeAPISession,
     GenericHordeAPIManualClient,
     GenericHordeAPISession,
+    _default_sslcontext,
 )
 
 
@@ -291,12 +293,18 @@ class AIHordeAPIManualClient(GenericHordeAPIManualClient, BaseAIHordeClient):
 class AIHordeAPIAsyncManualClient(GenericAsyncHordeAPIManualClient, BaseAIHordeClient):
     """An asyncio based API client specifically configured for the AI-Horde API."""
 
-    def __init__(self, aiohttp_session: aiohttp.ClientSession) -> None:
+    def __init__(
+        self,
+        aiohttp_session: aiohttp.ClientSession,
+        *,
+        ssl_context: SSLContext = _default_sslcontext,
+    ) -> None:
         """Create a new instance of the RatingsAPIClient."""
         super().__init__(
             aiohttp_session=aiohttp_session,
             path_fields=AIHordePathData,
             query_fields=AIHordeQueryData,
+            ssl_context=ssl_context,
         )
 
     async def get_generate_check(
@@ -395,12 +403,14 @@ class AIHordeAPIAsyncClientSession(GenericAsyncHordeAPISession):
     def __init__(
         self,
         aiohttp_session: aiohttp.ClientSession,
+        ssl_context: SSLContext = _default_sslcontext,
     ) -> None:
         """Create a new instance of the RatingsAPIClient."""
         super().__init__(
             aiohttp_session=aiohttp_session,
             path_fields=AIHordePathData,
             query_fields=AIHordeQueryData,
+            ssl_context=ssl_context,
         )
 
 

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -409,6 +409,7 @@ class GenericAsyncHordeAPIManualClient(BaseHordeAPIClient):
         path_fields: type[GenericPathFields] = GenericPathFields,
         query_fields: type[GenericQueryFields] = GenericQueryFields,
         accept_types: type[GenericAcceptTypes] = GenericAcceptTypes,
+        ssl_context: SSLContext = _default_sslcontext,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         super().__init__(
@@ -673,6 +674,7 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
         path_fields: type[GenericPathFields] = GenericPathFields,
         query_fields: type[GenericQueryFields] = GenericQueryFields,
         accept_types: type[GenericAcceptTypes] = GenericAcceptTypes,
+        ssl_context: SSLContext = _default_sslcontext,
     ) -> None:
         super().__init__(
             aiohttp_session=aiohttp_session,
@@ -680,6 +682,7 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
             path_fields=path_fields,
             query_fields=query_fields,
             accept_types=accept_types,
+            ssl_context=ssl_context,
         )
         self._pending_follow_ups = []
         self._awaiting_requests = []

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -105,6 +105,8 @@ class BaseHordeAPIClient(ABC):
                 Defaults to GenericQueryFields.
             accept_types (type[GenericAcceptTypes], optional): Pass this to define the API's accept types.
                 Defaults to GenericAcceptTypes.
+            ssl_context (SSLContext, optional): The SSL context to use for aiohttp requests.
+                Defaults to using `certifi`.
             kwargs: Any additional keyword arguments are ignored.
 
         Raises:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydantic==2.9.2
 requests
 StrEnum
 loguru
+certifi
 aiohttp
 aiofiles
 aiodns


### PR DESCRIPTION
The hope of this change is to fix an issue where uploads to cloudflare on a fresh windows 10 pro machine would fail due to being unable to resolve the system's cert store for the relevant root authority certificate. Despite being sure the cert was installed and various other troubleshooting efforts, only by utilizing certifi to resolve the cert store ultimately resolved the issue.