### PR TITLE
fix: config default root models to allow new API fields

### DIFF
--- a/horde_sdk/ai_horde_api/apimodels/base.py
+++ b/horde_sdk/ai_horde_api/apimodels/base.py
@@ -199,7 +199,9 @@ class ImageGenerateParamMixin(HordeAPIDataObject):
     """
 
     model_config = (
-        ConfigDict(frozen=True) if not os.getenv("TESTS_ONGOING") else ConfigDict(frozen=True, extra="forbid")
+        ConfigDict(frozen=True, extra="allow")
+        if not os.getenv("TESTS_ONGOING")
+        else ConfigDict(frozen=True, extra="forbid")
     )
 
     sampler_name: KNOWN_SAMPLERS | str = KNOWN_SAMPLERS.k_lms

--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -58,6 +58,7 @@ class HordeAPIDataObject(BaseModel):
         ConfigDict(
             frozen=True,
             use_attribute_docstrings=True,
+            extra="allow",
         )
         if not os.getenv("TESTS_ONGOING")
         else ConfigDict(
@@ -98,7 +99,9 @@ class HordeResponseBaseModel(HordeResponse, BaseModel):
     """Base class for all Horde API response data models (leveraging pydantic)."""
 
     model_config = (
-        ConfigDict(frozen=True) if not os.getenv("TESTS_ONGOING") else ConfigDict(frozen=True, extra="forbid")
+        ConfigDict(frozen=True, extra="allow")
+        if not os.getenv("TESTS_ONGOING")
+        else ConfigDict(frozen=True, extra="forbid")
     )
 
 


### PR DESCRIPTION
This doesn't automatically bring support for any intended functionality but in the case of informational model dumps, such as for the `skipped` info on a job pop or user/worker info responses this will allow some forwards compatibility in the case new fields are added to already known API models.