### PR TITLE
fix: allow extra attribs for HordeAPIObject

### DIFF
--- a/horde_sdk/generic_api/apimodels.py
+++ b/horde_sdk/generic_api/apimodels.py
@@ -40,9 +40,17 @@ class HordeAPIObject(BaseModel, abc.ABC):
         If none, there is no payload, such as for a GET request.
         """
 
-    model_config = ConfigDict(
-        frozen=True,
-        use_attribute_docstrings=True,
+    model_config = (
+        ConfigDict(
+            frozen=True,
+            use_attribute_docstrings=True,
+            extra="allow",
+        )
+        if not os.getenv("TESTS_ONGOING")
+        else ConfigDict(
+            frozen=True,
+            use_attribute_docstrings=True,
+        )
     )
 
 


### PR DESCRIPTION
This makes this class consistent with `HordeAPIDataObject` and my intentions. Practically speaking, for forward compatibility and in a live situation we want to allow additional information to propagate from the API to an end user where possible.