### PR TITLE
fix: expose apikey as intended

### DIFF
--- a/horde_sdk/ai_horde_api/ai_horde_clients.py
+++ b/horde_sdk/ai_horde_api/ai_horde_clients.py
@@ -403,10 +403,12 @@ class AIHordeAPIAsyncClientSession(GenericAsyncHordeAPISession):
         self,
         aiohttp_session: aiohttp.ClientSession,
         ssl_context: SSLContext = _default_sslcontext,
+        apikey: str | None = None,
     ) -> None:
         """Create a new instance of the RatingsAPIClient."""
         super().__init__(
             aiohttp_session=aiohttp_session,
+            apikey=apikey,
             path_fields=AIHordePathData,
             query_fields=AIHordeQueryData,
             ssl_context=ssl_context,
@@ -1250,6 +1252,7 @@ class AIHordeAPIAsyncSimpleClient(BaseAIHordeSimpleClient):
         self,
         aiohttp_session: aiohttp.ClientSession | None = None,
         horde_client_session: AIHordeAPIAsyncClientSession | None = None,
+        apikey: str | None = None,
     ) -> None:
         """Create a new instance of the AIHordeAPISimpleClient."""
         super().__init__()
@@ -1267,7 +1270,7 @@ class AIHordeAPIAsyncSimpleClient(BaseAIHordeSimpleClient):
         if aiohttp_session is not None and horde_client_session is None:
             logger.info("Creating a new AIHordeAPIAsyncClientSession with the provided aiohttp session.")
             self._aiohttp_session = aiohttp_session
-            self._horde_client_session = AIHordeAPIAsyncClientSession(aiohttp_session)
+            self._horde_client_session = AIHordeAPIAsyncClientSession(aiohttp_session, apikey=apikey)
         elif horde_client_session is not None:
             self._horde_client_session = horde_client_session
             self._aiohttp_session = horde_client_session._aiohttp_session

--- a/horde_sdk/generic_api/generic_clients.py
+++ b/horde_sdk/generic_api/generic_clients.py
@@ -496,6 +496,7 @@ class GenericHordeAPISession(GenericHordeAPIManualClient):
     def __init__(
         self,
         *,
+        apikey: str | None = None,
         header_fields: type[GenericHeaderFields] = GenericHeaderFields,
         path_fields: type[GenericPathFields] = GenericPathFields,
         query_fields: type[GenericQueryFields] = GenericQueryFields,
@@ -503,6 +504,7 @@ class GenericHordeAPISession(GenericHordeAPIManualClient):
     ) -> None:
         """Initialize a new `GenericHordeAPISession` instance."""
         super().__init__(
+            apikey=apikey,
             header_fields=header_fields,
             path_fields=path_fields,
             query_fields=query_fields,
@@ -674,6 +676,7 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
         self,
         aiohttp_session: aiohttp.ClientSession,
         *,
+        apikey: str | None = None,
         header_fields: type[GenericHeaderFields] = GenericHeaderFields,
         path_fields: type[GenericPathFields] = GenericPathFields,
         query_fields: type[GenericQueryFields] = GenericQueryFields,
@@ -681,6 +684,7 @@ class GenericAsyncHordeAPISession(GenericAsyncHordeAPIManualClient):
         ssl_context: SSLContext = _default_sslcontext,
     ) -> None:
         super().__init__(
+            apikey=apikey,
             aiohttp_session=aiohttp_session,
             header_fields=header_fields,
             path_fields=path_fields,

--- a/horde_sdk/horde_logging.py
+++ b/horde_sdk/horde_logging.py
@@ -90,4 +90,4 @@ if HORDE_SDK_LOG_VERBOSITY is not None:
 set_logger_handlers = os.getenv("HORDE_SDK_SET_DEFAULT_LOG_HANDLERS")
 
 if set_logger_handlers:
-    logger.configure(handlers=handler_config)
+    logger.configure(handlers=handler_config)  # type: ignore


### PR DESCRIPTION
The failure to expose this argument leads to recovery operations not working as intended/expected